### PR TITLE
Add workouts

### DIFF
--- a/components/WorkoutTable.tsx
+++ b/components/WorkoutTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Workout } from '../types/workout';
+import { isDateInRange } from '../utils/date';
 import WorkoutLineItem from './WorkoutLineItem';
 
 type WorkoutTableProps = {
@@ -20,7 +21,7 @@ const WorkoutTable = ({ endDate, startDate, workouts }: WorkoutTableProps) => (
                 // Dates come back from API as string and need to be converted to Date before filtering and sorting
                 .map(workout => ({ ...workout, date: new Date(workout.date) }))
                 // Limit workouts in the table between startDate and endDate
-                .filter(workout => workout.date >= startDate && workout.date <= endDate)
+                .filter(workout => isDateInRange(workout.date, startDate, endDate))
                 // Sort workouts by date descending
                 .sort((a, b) => b.date.getTime() - a.date.getTime())
                 // Render a WorkoutLineItem to display each workout

--- a/components/WorkoutTable.tsx
+++ b/components/WorkoutTable.tsx
@@ -3,17 +3,29 @@ import { Workout } from '../types/workout';
 import WorkoutLineItem from './WorkoutLineItem';
 
 type WorkoutTableProps = {
+    endDate: Date;
+    startDate: Date;
     workouts: Workout[];
 };
 
-const WorkoutTable = ({ workouts }: WorkoutTableProps) => (
+const WorkoutTable = ({ endDate, startDate, workouts }: WorkoutTableProps) => (
     <table>
         <tr>
             <th>Date</th>
             <th>Duration</th>
             <th>Type</th>
         </tr>
-        {workouts.map(workout => <WorkoutLineItem key={workout.id} workout={workout} />)}
+        {
+            workouts
+                // Dates come back from API as string and need to be converted to Date before filtering and sorting
+                .map(workout => ({ ...workout, date: new Date(workout.date) }))
+                // Limit workouts in the table between startDate and endDate
+                .filter(workout => workout.date >= startDate && workout.date <= endDate)
+                // Sort workouts by date descending
+                .sort((a, b) => b.date.getTime() - a.date.getTime())
+                // Render a WorkoutLineItem to display each workout
+                .map(workout => <WorkoutLineItem key={workout.id} workout={workout} />)
+        }
     </table>
 );
 

--- a/db/models.ts
+++ b/db/models.ts
@@ -12,11 +12,6 @@ const userSchema = new Schema({
 });
 
 const workoutSchema = new Schema({
-    id: {
-        type: String,
-        required: true,
-        unique: true
-    },
     date: Date,
     duration: Number,
     type: String,

--- a/pages/add-workout.tsx
+++ b/pages/add-workout.tsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useState } from 'react';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { NextRouter, useRouter } from 'next/router';
+import { getSession } from 'next-auth/react';
+import { User } from '../types/user';
+
+type AddWorkoutProps = {
+    user: User;
+};
+
+type AddWorkoutArgs = {
+    date: Date | null;
+    duration: number;
+    router: NextRouter;
+    setError: (error: string) => void;
+    type: string;
+    userId: string;
+};
+
+const addWorkout = async ({
+    date,
+    duration,
+    router,
+    setError,
+    type,
+    userId
+}: AddWorkoutArgs) => {
+    if (duration < 0) {
+        setError('Duration must be greater than 0');
+        return;
+    }
+
+    if (!type) {
+        setError('Please select a type');
+        return;
+    }
+
+    await fetch(`/api/workouts/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            date,
+            duration,
+            type,
+            userId
+        }),
+    });
+
+    router.push('/');
+}
+
+const AddWorkout = ({ user }: AddWorkoutProps) => {
+    const router = useRouter();
+    const [date, setDate] = useState<Date | null>(null);
+    const [duration, setDuration] = useState<number>(0);
+    const [error, setError] = useState<string>('');
+    const [type, setType] = useState<string>('');
+
+    const handleSave = useCallback(() => addWorkout({
+        date,
+        duration,
+        router,
+        setError,
+        type,
+        userId: user?.id
+    }), [date, duration, router, type, user]);
+
+    return (
+        <form>
+            <p>Add workout</p>
+            <input
+                name='date'
+                onChange={(e) => setDate(new Date(e.target.value))}
+                type='date'
+            />
+            <input
+                min={0}
+                name='duration'
+                onChange={(e) => setDuration(parseInt(e.target.value))}
+                type='number'
+            />
+            <select
+                id='type'
+                name='type'
+                onChange={(e) => setType(e.target.value)}
+                required
+            >
+                <option value='' disabled selected>Select a workout type</option>
+                <option value='Bike'>Bike</option>
+                <option value='Cardio'>Cardio</option>
+                <option value='Run'>Run</option>
+                <option value='Strength'>Strength</option>
+                <option value='Weights'>Weights</option>
+                <option value='Other'>Other</option>
+            </select>
+            {error && <p>{error}</p>}
+            <button onClick={(e) => {
+                e.preventDefault();
+                handleSave();
+            }}>SAVE</button>
+        </form>
+    );
+};
+
+export const getServerSideProps: GetServerSideProps<AddWorkoutProps> = async (context: GetServerSidePropsContext) => {
+    const session = await getSession(context);
+    const userId = session?.user?.id;
+
+    if (userId) {
+        const res = await fetch(`${process.env.API_BASE_URL}/api/users/${userId}`);
+        const { user } = await res.json();
+
+        return {
+            props: {
+                session,
+                user: user
+            }
+        };
+    } else {
+        return {
+            redirect: {
+                destination: '/login',
+                permanent: false
+            }
+        }
+    }
+}
+
+export default AddWorkout;

--- a/pages/api/workouts/create.ts
+++ b/pages/api/workouts/create.ts
@@ -14,12 +14,12 @@ const handler = async (
     req: NextApiRequest,
     res: NextApiResponse<WorkoutData | ErrorData>
 ) => {
-    const { userId } = req.body;
+    const { date, duration, type, userId } = req.body;
 
     try {
         await connectMongo();
-        const user = await User.findOne({ id: '101927703181492899764' });
-        const workout = await Workout.create({ id: 1, date: Date.now(), duration: 30, type: 'Run', user });
+        const user = await User.findOne({ id: userId });
+        const workout = await Workout.create({ date, duration, type, user });
         user.workouts.push(workout);
         user.save();
         res.status(200).json({ workout })

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,13 @@ import { getSession, signOut } from 'next-auth/react';
 import WeeklyTarget from '../components/WeeklyTarget';
 import { User } from '../types/user';
 import WorkoutTable from '../components/WorkoutTable';
-import { getMondayOfCurrentWeek, getMondayOfNextWeek, getTenYearsAgo } from '../utils/date';
+import {
+    getEndOfCurrentWeek,
+    getEndOfPreviousWeek,
+    getStartOfCurrentWeek,
+    getTenYearsAgo
+} from '../utils/date';
+import { formatDate } from '../utils/formatters';
 
 type IndexProps = {
     session: Session;
@@ -14,24 +20,25 @@ type IndexProps = {
 
 const Index = ({ session, user }: IndexProps) => {
     if (session?.user && user) {
-        const startOfThisWeek = getMondayOfCurrentWeek();
-        const startOfNextWeek = getMondayOfNextWeek();
+        const endOfCurrentWeek = getEndOfCurrentWeek();
+        const endOfPreviousWeek = getEndOfPreviousWeek();
+        const StartOfCurrentWeek = getStartOfCurrentWeek();
         const tenYearsAgo = getTenYearsAgo();
 
         return (
             <div>
                 <WeeklyTarget weeklyTarget={user.weeklyTarget} />
                 <hr />
-                <h3>This Week</h3>
+                <h3>This Week ({formatDate(StartOfCurrentWeek)} - {formatDate(endOfCurrentWeek)})</h3>
                 <WorkoutTable
-                    endDate={startOfNextWeek}
-                    startDate={startOfThisWeek}
+                    endDate={endOfCurrentWeek}
+                    startDate={StartOfCurrentWeek}
                     workouts={user.workouts}
                 />
                 <hr />
                 <h3>All Time</h3>
                 <WorkoutTable
-                    endDate={startOfThisWeek}
+                    endDate={endOfPreviousWeek}
                     startDate={tenYearsAgo}
                     workouts={user.workouts}
                 />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import { Session } from 'next-auth';
 import { getSession, signOut } from 'next-auth/react';
-import Image from 'next/image';
 import WeeklyTarget from '../components/WeeklyTarget';
 import { User } from '../types/user';
 import WorkoutTable from '../components/WorkoutTable';
+import { getMondayOfCurrentWeek, getMondayOfNextWeek, getTenYearsAgo } from '../utils/date';
 
 type IndexProps = {
     session: Session;
@@ -14,11 +14,27 @@ type IndexProps = {
 
 const Index = ({ session, user }: IndexProps) => {
     if (session?.user && user) {
+        const startOfThisWeek = getMondayOfCurrentWeek();
+        const startOfNextWeek = getMondayOfNextWeek();
+        const tenYearsAgo = getTenYearsAgo();
+
         return (
             <div>
                 <WeeklyTarget weeklyTarget={user.weeklyTarget} />
                 <hr />
-                <WorkoutTable workouts={user.workouts} />
+                <h3>This Week</h3>
+                <WorkoutTable
+                    endDate={startOfNextWeek}
+                    startDate={startOfThisWeek}
+                    workouts={user.workouts}
+                />
+                <hr />
+                <h3>All Time</h3>
+                <WorkoutTable
+                    endDate={startOfThisWeek}
+                    startDate={tenYearsAgo}
+                    workouts={user.workouts}
+                />
             </div>
         );
     } else {

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,19 +1,63 @@
-export const getMondayOfCurrentWeek = (): Date => {
+export const getStartOfCurrentWeek = (): Date => {
     const today = new Date();
-    const first = today.getDate() - today.getDay() + 1;
-    const monday = new Date(today.setDate(first));
+    const monday = new Date();
+
+    // Set date to Monday of the current week
+    monday.setDate(today.getDate() - today.getDay() + 1)
+    // Set time to beginning of day
+    monday.setUTCHours(0, 0, 0);
+
     return monday;
 };
 
-export const getMondayOfNextWeek = (): Date => {
+export const getEndOfCurrentWeek = (): Date => {
     const today = new Date();
-    const first = today.getDate() - today.getDay() + 8;
-    const monday = new Date(today.setDate(first));
+    const monday = new Date();
+
+    // Set date to Monday of the following week
+    monday.setDate(today.getDate() - today.getDay() + 7)
+    // Set time to beginning of day
+    monday.setUTCHours(0, 0, 0);
+
     return monday;
+};
+
+export const getEndOfPreviousWeek = (): Date => {
+    const mondayOfCurrentWeek = getStartOfCurrentWeek();
+
+    return new Date(mondayOfCurrentWeek.setDate(mondayOfCurrentWeek.getDate() - 1));
 };
 
 export const getTenYearsAgo = (): Date => {
     const today = new Date();
+
+    // Set year to 10 years ago
     const tenYearsAgo = new Date(today.setFullYear(today.getFullYear() - 10));
+    // Set time to beginning of day
+    tenYearsAgo.setUTCHours(0, 0, 0);
+
     return tenYearsAgo;
 };
+
+/**
+ * Checks if a given date falls in a given date range exclsuive of time of day
+ *
+ * @param date The input date
+ * @param startDate The start of the date range
+ * @param endDate The end of the date range
+ * @returns True if the input date falls between the start date and the end date inclusive
+ */
+export const isDateInRange = (date: Date, startDate: Date, endDate: Date): boolean => {
+    if (
+        date.getFullYear() < startDate.getFullYear() ||
+        date.getFullYear() > endDate.getFullYear() ||
+        (date.getFullYear() === startDate.getFullYear() && date.getMonth() < startDate.getMonth()) ||
+        (date.getFullYear() === endDate.getFullYear() && date.getMonth() > endDate.getMonth()) ||
+        (date.getFullYear() === startDate.getFullYear() && date.getMonth() === startDate.getMonth() && date.getDate() < startDate.getDate()) ||
+        (date.getFullYear() === endDate.getFullYear() && date.getMonth() === endDate.getMonth() && date.getDate() > endDate.getDate())
+    ) {
+        return false;
+    }
+
+    return true;
+}

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,0 +1,19 @@
+export const getMondayOfCurrentWeek = (): Date => {
+    const today = new Date();
+    const first = today.getDate() - today.getDay() + 1;
+    const monday = new Date(today.setDate(first));
+    return monday;
+};
+
+export const getMondayOfNextWeek = (): Date => {
+    const today = new Date();
+    const first = today.getDate() - today.getDay() + 8;
+    const monday = new Date(today.setDate(first));
+    return monday;
+};
+
+export const getTenYearsAgo = (): Date => {
+    const today = new Date();
+    const tenYearsAgo = new Date(today.setFullYear(today.getFullYear() - 10));
+    return tenYearsAgo;
+};

--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -11,8 +11,8 @@ export const formatDate = (date: Date): string => {
 
     date = new Date(date);
 
-    const day = date.getDate();
-    const month = date.getMonth();
+    const day = date.getDate() + 1;
+    const month = date.getMonth() + 1;
     const year = date.getFullYear();
 
     let dayString = `${day}`;


### PR DESCRIPTION
- Fix `/api/workouts/create` endpoint to allow client to pass custom data
- Implement an `/add-workout` route, page, and form
- Display two tables of workout data: One for the current week and one for historical data (prior to the current week)
- Implement formatting, filtering, and sorting by date in `WorkoutTable`